### PR TITLE
ansible tasks for exposing a sandstorm hidden service, issue #14

### DIFF
--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -20,6 +20,12 @@
     - "/etc/nginx/ssl"
     - "/var/log/nginx/{{ sandstorm_hostname }}"
 
+- name: create onion nginx dirs
+  file: name="{{ item }}" state=directory owner=www-data
+  when: sandstorm_onion
+  with_items:
+    - "/var/log/nginx/sandstorm_onion_proxy"
+
 - name: copy dh params
   copy:
     src: dhparam.pem

--- a/tasks/tor.yml
+++ b/tasks/tor.yml
@@ -20,6 +20,16 @@
   register: descriptor_cookie
   when: ssh_onion and torrc.changed
 
+- name: Grab sandstorm onion address
+  shell: cat /var/lib/tor/sandstorm/hostname | awk '{print $1}'
+  register: sandstorm_onion_address
+  when: sandstorm_onion and torrc.changed
+
+- name: Grab sandstorm client descriptor cookie
+  shell: cat /var/lib/tor/sandstorm/hostname | awk '{print $2}'
+  register: sandstorm_descriptor_cookie
+  when: sandstorm_onion and torrc.changed
+
 - name: IMPORTANT! Here is your ssh onion address, you will need this to
     administer your server!
   debug: msg="{{onion_address.stdout}}"
@@ -28,3 +38,12 @@
 - name: IMPORTANT! You also need to add this auth key to your torrc
   debug: msg="HidServAuth {{onion_address.stdout}} {{descriptor_cookie.stdout}}"
   when: ssh_onion and torrc.changed
+
+- name: IMPORTANT! Here is your sandstorm onion address, you will need this to
+    administer your server!
+  debug: msg="{{sandstorm_onion_address.stdout}}"
+  when: sandstorm_onion and torrc.changed
+
+- name: IMPORTANT! You also need to add this auth key to your torrc
+  debug: msg="HidServAuth {{sandstorm_onion_address.stdout}} {{sandstorm_descriptor_cookie.stdout}}"
+  when: sandstorm_onion and torrc.changed


### PR DESCRIPTION
Adding `sandstorm_onion: true` to `test.yml` enables this feature.  Leaving off by default due to information leak issues described in #14 
