### PR TITLE
Prevent DNS leaks when providing sandstorm tor hidden service

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,8 @@ firewall_allowed_tcp_ports:
   - 80
   - 443
 
+tor_isolate_dns: "{{sandstorm_onion}}"
+
 fail2ban_service_enabled: yes
 
 fail2ban_service_state: started

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -20,6 +20,12 @@
     - "/etc/nginx/ssl"
     - "/var/log/nginx/{{ sandstorm_hostname }}"
 
+- name: create onion nginx dirs
+  file: name="{{ item }}" state=directory owner=www-data
+  when: sandstorm_onion
+  with_items:
+    - "/var/log/nginx/sandstorm_onion_proxy"
+
 - name: copy dh params
   copy:
     src: dhparam.pem

--- a/tasks/tor.yml
+++ b/tasks/tor.yml
@@ -20,6 +20,16 @@
   register: descriptor_cookie
   when: ssh_onion and torrc.changed
 
+- name: Grab sandstorm onion address
+  shell: cat /var/lib/tor/sandstorm/hostname | awk '{print $1}'
+  register: sandstorm_onion_address
+  when: sandstorm_onion and torrc.changed
+
+- name: Grab sandstorm client descriptor cookie
+  shell: cat /var/lib/tor/sandstorm/hostname | awk '{print $2}'
+  register: sandstorm_descriptor_cookie
+  when: sandstorm_onion and torrc.changed
+
 - name: IMPORTANT! Here is your ssh onion address, you will need this to
     administer your server!
   debug: msg="{{onion_address.stdout}}"
@@ -28,3 +38,12 @@
 - name: IMPORTANT! You also need to add this auth key to your torrc
   debug: msg="HidServAuth {{onion_address.stdout}} {{descriptor_cookie.stdout}}"
   when: ssh_onion and torrc.changed
+
+- name: IMPORTANT! Here is your sandstorm onion address, you will need this to
+    administer your server!
+  debug: msg="{{sandstorm_onion_address.stdout}}"
+  when: sandstorm_onion and torrc.changed
+
+- name: IMPORTANT! You also need to add this auth key to your torrc
+  debug: msg="HidServAuth {{sandstorm_onion_address.stdout}} {{sandstorm_descriptor_cookie.stdout}}"
+  when: sandstorm_onion and torrc.changed

--- a/tasks/tor.yml
+++ b/tasks/tor.yml
@@ -10,6 +10,10 @@
   service: name=tor state=restarted enabled=yes
   when: torrc.changed
 
+- name: Update /etc/resolv.conf to point to Tor
+  template: src=resolv.conf.j2 dest=/etc/resolv.conf
+  when: tor_isolate_dns and torrc.changed
+
 - name: Grab ssh onion address
   shell: cat /var/lib/tor/ssh/hostname | awk '{print $1}'
   register: onion_address

--- a/templates/resolv.conf.j2
+++ b/templates/resolv.conf.j2
@@ -1,0 +1,1 @@
+nameserver 127.0.0.1

--- a/templates/torrc.j2
+++ b/templates/torrc.j2
@@ -2,6 +2,10 @@ SocksPort 0
 RunAsDaemon 1
 Sandbox 1
 
+{% if tor_isolate_dns %}
+DNSPort 53
+{% endif %}
+
 {% if ssh_onion %}
 HiddenServiceDir /var/lib/tor/ssh/
 HiddenServicePort 22 127.0.0.1:22


### PR DESCRIPTION
This feature encourages DNS requests to be resolved using Tor when `sandstorm_onion: true`.  Only A records are resolved in this manner.  Other DNS records will not return a result.  To disable this feature, set `tor_isolate_dns: false`.  Part 1 of issue #25 
