### PR TITLE
remove HidServAuth output for sandstorm_onion, issue #14

### DIFF
--- a/tasks/tor.yml
+++ b/tasks/tor.yml
@@ -25,11 +25,6 @@
   register: sandstorm_onion_address
   when: sandstorm_onion and torrc.changed
 
-- name: Grab sandstorm client descriptor cookie
-  shell: cat /var/lib/tor/sandstorm/hostname | awk '{print $2}'
-  register: sandstorm_descriptor_cookie
-  when: sandstorm_onion and torrc.changed
-
 - name: IMPORTANT! Here is your ssh onion address, you will need this to
     administer your server!
   debug: msg="{{onion_address.stdout}}"
@@ -44,6 +39,3 @@
   debug: msg="{{sandstorm_onion_address.stdout}}"
   when: sandstorm_onion and torrc.changed
 
-- name: IMPORTANT! You also need to add this auth key to your torrc
-  debug: msg="HidServAuth {{sandstorm_onion_address.stdout}} {{sandstorm_descriptor_cookie.stdout}}"
-  when: sandstorm_onion and torrc.changed


### PR DESCRIPTION
As mentioned in code comments on issue #14 , HidServAuth is illogical for http, removing to avoid confusion. 
