### PR TITLE
Disable ipv6 using kernel parameter

### DIFF
--- a/tasks/disable-ipv6.yml
+++ b/tasks/disable-ipv6.yml
@@ -1,0 +1,21 @@
+---
+- name: add ipv6.disable=1 to grub command line
+  lineinfile:
+    dest: /etc/default/grub
+    backrefs: yes
+    regexp: 'GRUB_CMDLINE_LINUX_DEFAULT="quiet"'
+    line: 'GRUB_CMDLINE_LINUX_DEFAULT="quiet ipv6.disable=1"'
+  register: grubcommandline
+
+- name: update grub
+  command: update-grub
+  when: grubcommandline.changed
+
+- name: restart server with 1 minute delay
+  command: shutdown -r 1
+  when: grubcommandline.changed
+
+- name: waiting for server to become available
+  sudo: false
+  local_action: wait_for port="{{ ansible_ssh_port | default(22) }}" host="{{ ansible_ssh_host | default(inventory_hostname) }}" search_regex=OpenSSH delay=75
+  when: grubcommandline.changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,3 +29,6 @@
 - include: tor.yml
   tags: tor
   when: ssh_onion or sandstorm_onion
+
+- include: disable-ipv6.yml
+  tags: ipv6


### PR DESCRIPTION
I don't like the restart logic here very much because it adds an extra
75 seconds of provisioning time. The reason it does that is because one
minute is the minimum value shutdown will take, and I need a command
that will reboot the server and return an exit code before the box goes
down. I was thinking about adding it to the Vagrantfile as a shell
provisioner, but then it wouldn't happen on real hosts unless we wrote
the documentation on how to use vagrant as a bare metal provisioner...
