### PR TITLE
Centralized logging with ELK and filebeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ for details on the SSL fields.
 
 See `test/gen-duplicity-keys.sh` for an example of generating the backup keys.
 
+### Centralized logging
+* **elasticsearch_addresses**: A list of addresses to the ES clusters intended
+to receive logs. Can be specified as a URI or IP:PORT
+* **filebeat_prospectors**: A list of hashes containing the path to the file(s)
+to be logged, and the `document_type` for ES indexing
+* **filebeat_ssl_enabled**: enable ssl configuration for filebeat client; if
+this is set to false, the following variables are ignored
+* **filebeat_certificate_path**: certificate for TLS client authentication
+* **filebeat_certificate_key_path**: client Certificate Key
+* **filebeat_certificate_authorities**: list of root certificates for HTTPS
+server verifications
+
+See `test/gen-filebeat-keys.sh` for an example of generating the filebeat keys.
+
 ### Other
 
 * **firewall_allowed_tcp_ports**: defaults to `[80, 443]`. add
@@ -93,6 +107,7 @@ You can see `test.yml` in action with Vagrant:
 * `ansible-galaxy install -r requirements.yml`
 * `./test/gen-duplicity-keys.sh`
 * `./test/gen-test-cert.sh`
+* `./test/gen-filebeat-cert.sh`
 * Add `test/rootCA.pem` to your browsers trusted authorities list (**note!**
   while this is added to your browser anyone with access to rootCA.key will be
   able to compromise your TLS connections)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,30 +6,33 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  config.vm.box = "debian/jessie64"
+  config.vm.define :sandstorm do |sandstorm|
 
-  config.vm.provider "virtualbox" do |vb|
-    vb.customize ["modifyvm", :id, "--usb", "off"]
-    vb.customize ["modifyvm", :id, "--usbehci", "off"]
+    sandstorm.vm.box = "debian/jessie64"
+
+    sandstorm.vm.provider "virtualbox" do |vb|
+      vb.customize ["modifyvm", :id, "--usb", "off"]
+      vb.customize ["modifyvm", :id, "--usbehci", "off"]
+    end
+
+    sandstorm.vm.hostname = 'sandstorm.172.19.22.22.xip.io'
+    sandstorm.vm.network "private_network", ip: "172.19.22.22"
+
+    # Setup a loop device so we can test debops.cryptsetup in Vagrant
+    sandstorm.vm.provision "shell", inline: <<-EOF
+      if [ ! -f "/tmp/loop0-file" ]; then
+        dd if=/dev/zero of=/tmp/loop0-file bs=1M count=1000
+      fi
+      if [ ! -e "/dev/loop0" ]; then
+        losetup /dev/loop0 /tmp/loop0-file
+      fi
+    EOF
+
+    sandstorm.vm.provision :ansible do |ansible|
+      ansible.playbook = "test.yml"
+      # ansible.verbose = "vvvv"
+      ansible.tags = "filebeat"
+      ansible.skip_tags = "ssh"
+    end
   end
-
-  config.vm.hostname = 'sandstorm.172.19.22.22.xip.io'
-  config.vm.network "private_network", ip: "172.19.22.22"
-
-  # Setup a loop device so we can test debops.cryptsetup in Vagrant
-  config.vm.provision "shell", inline: <<-EOF
-    if [ ! -f "/tmp/loop0-file" ]; then
-      dd if=/dev/zero of=/tmp/loop0-file bs=1M count=1000
-    fi
-    if [ ! -e "/dev/loop0" ]; then
-      losetup /dev/loop0 /tmp/loop0-file
-    fi
-  EOF
-
-  config.vm.provision :ansible do |ansible|
-    ansible.playbook = "test.yml"
-    # ansible.verbose = "vvvv"
-    # ansible.tags = ""
-  end
-
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,9 +30,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     sandstorm.vm.provision :ansible do |ansible|
       ansible.playbook = "test.yml"
-      # ansible.verbose = "vvvv"
-      ansible.tags = "filebeat"
       ansible.skip_tags = "ssh"
+      # ansible.verbose = "vvvv"
+      # ansible.tags = ""
     end
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,4 +35,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       # ansible.tags = ""
     end
   end
+
+  config.vm.define :elk do |elk|
+    elk.vm.provider "docker" do |d|
+      d.name = "homelessELK"
+      d.image =  "blacktop/elk"
+      d.ports = ['80:80', '9200:9200']
+      d.expose = [443, 9300]
+      d.remains_running = true
+    end
+  end
 end

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,3 +43,5 @@ backup_max_age: '7D'
 cryptsetup_devices:
  - name: 'sandstorm-data'
    ciphertext_block_device: "{{ sandstorm_ciphertext_block_device }}"
+
+filebeat_ssl_enabled: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,3 +12,7 @@
   service:
     name: fail2ban
     state: restarted
+- name: restart filebeat
+  service:
+    name: filebeat
+    state: restarted

--- a/tasks/filebeat.yml
+++ b/tasks/filebeat.yml
@@ -1,0 +1,15 @@
+---
+- name: Get filebeat
+  get_url: url=https://download.elastic.co/beats/filebeat/filebeat_1.1.2_amd64.deb dest=/tmp/filebeat_1.1.2_amd64.deb mode=0755
+
+- name: Install filebeat
+  apt: deb=/tmp/filebeat_1.1.2_amd64.deb
+
+- name: Configure filebeat
+  template: src=filebeat.yml.j2 dest=/etc/filebeat/filebeat.yml
+
+- name: reload filebeat
+  service: name=filebeat state=restarted
+
+#- name: load filebeat template into ES
+#  shell: curl -XPUT 'http://172.19.22.1:9200_template/filebeat?pretty' -d@/etc/filebeat/filebeat.template.json

--- a/tasks/filebeat.yml
+++ b/tasks/filebeat.yml
@@ -1,15 +1,42 @@
 ---
-- name: Get filebeat
-  get_url: url=https://download.elastic.co/beats/filebeat/filebeat_1.1.2_amd64.deb dest=/tmp/filebeat_1.1.2_amd64.deb mode=0755
+- name: Add filebeat repository key
+  apt_key:
+    url: https://packages.elastic.co/GPG-KEY-elasticsearch
+    state: present
+
+- name: Add filebeat repository
+  apt_repository:
+    repo: "deb http://packages.elastic.co/beats/apt stable main"
 
 - name: Install filebeat
-  apt: deb=/tmp/filebeat_1.1.2_amd64.deb
+  apt: pkg=filebeat
+
+- name: Create Filebeat ssl dir
+  file:
+    name="/etc/filebeat/ssl"
+    recurse=true
+    state=directory
+    owner=root
+    mode=0700
+  when: filebeat_ssl_enabled
+
+- name: Copy filebeat client certificate
+  copy:
+    src={{ filebeat_certificate_path }}
+    dest=/etc/filebeat/ssl/filebeat.crt
+  when: filebeat_ssl_enabled
+
+- name: Copy filebeat certificate key
+  copy:
+    src={{ filebeat_certificate_key_path }}
+    dest=/etc/filebeat/ssl/filebeat.key
+  when: filebeat_ssl_enabled
 
 - name: Configure filebeat
-  template: src=filebeat.yml.j2 dest=/etc/filebeat/filebeat.yml
-
-- name: reload filebeat
-  service: name=filebeat state=restarted
+  template:
+    src=filebeat.yml.j2
+    dest=/etc/filebeat/filebeat.yml
+  notify: restart filebeat
 
 #- name: load filebeat template into ES
 #  shell: curl -XPUT 'http://172.19.22.1:9200_template/filebeat?pretty' -d@/etc/filebeat/filebeat.template.json

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,3 +33,6 @@
 - include: tor.yml
   tags: tor
   when: ssh_onion or sandstorm_onion
+    
+- include: filebeat.yml
+  tags: filebeat

--- a/templates/filebeat.yml.j2
+++ b/templates/filebeat.yml.j2
@@ -1,0 +1,19 @@
+filebeat:
+  prospectors:
+    -
+      paths:
+        - "/var/log/*.log"
+        - "/var/log/syslog"
+      document_type: syslog
+    -
+      paths:
+        - "/opt/sandstorm/var/log/mongo.log"
+      document_type: mongo
+    -
+      paths:
+        - "/opt/sandstorm/var/log/sandstorm.log"
+      document_type: sandstorm
+      
+output:
+  elasticsearch:
+     hosts: ["172.19.22.1:9200"]

--- a/templates/filebeat.yml.j2
+++ b/templates/filebeat.yml.j2
@@ -1,19 +1,23 @@
 filebeat:
   prospectors:
-    -
-      paths:
-        - "/var/log/*.log"
-        - "/var/log/syslog"
-      document_type: syslog
-    -
-      paths:
-        - "/opt/sandstorm/var/log/mongo.log"
-      document_type: mongo
-    -
-      paths:
-        - "/opt/sandstorm/var/log/sandstorm.log"
-      document_type: sandstorm
-      
+  {% for item in filebeat_prospectors -%}
+  -
+    paths:
+      - "{{ item.path }}"
+    document_type: {{ item.document_type }}
+  {% endfor %}
+
 output:
   elasticsearch:
-     hosts: ["172.19.22.1:9200"]
+    hosts: {{ elasticsearch_addresses | to_yaml }}
+    {% if filebeat_ssl_enabled -%}
+    protocol: https
+    tls:
+      certificate_authorities:
+        {{ filebeat_certificate_authorities | to_nice_yaml -}}
+    {% endif %}
+
+logging:
+  level: warning
+  to_files: true
+  to_syslog: false

--- a/test.yml
+++ b/test.yml
@@ -24,3 +24,14 @@
       backup_enc_pub_key_path: test/backup-encryption-public.key
       backup_sig_priv_key_path: test/backup-signing-private.key
       sandstorm_ciphertext_block_device: '/dev/loop0'
+      logstash_forwarder_ssl_certificate_file: test/logstash-forwarder.crt
+      logstash_ssl_dir: /etc/ssl/logstash
+      logstash_forwarder_files:
+        - paths:
+            - /opt/sandstorm/var/log/mongo.log
+            - /opt/sandstorm/var/log/sandstorm.log
+            - /opt/sandstorm/var/log/updater.log
+          fields:
+            type: apache
+      logstash_forwarder_logstash_server: 172.19.22.1
+      logstash_forwarder_logstash_server_port: 9200

--- a/test.yml
+++ b/test.yml
@@ -24,14 +24,23 @@
       backup_enc_pub_key_path: test/backup-encryption-public.key
       backup_sig_priv_key_path: test/backup-signing-private.key
       sandstorm_ciphertext_block_device: '/dev/loop0'
-      logstash_forwarder_ssl_certificate_file: test/logstash-forwarder.crt
-      logstash_ssl_dir: /etc/ssl/logstash
-      logstash_forwarder_files:
-        - paths:
-            - /opt/sandstorm/var/log/mongo.log
-            - /opt/sandstorm/var/log/sandstorm.log
-            - /opt/sandstorm/var/log/updater.log
-          fields:
-            type: apache
-      logstash_forwarder_logstash_server: 172.19.22.1
-      logstash_forwarder_logstash_server_port: 9200
+      filebeat_prospectors:
+        - path: "/opt/sandstorm/var/log/updater.log"
+          document_type: "updates"
+        - path: "/opt/sandstorm/var/log/mongo.log"
+          document_type: "mongo"
+        - path: "/var/log/syslog"
+          document_type: "syslog"
+        - path: "/var/log/auth.log"
+          document_type: "auth"
+        - path: "/var/log/nginx/*.log"
+          document_type: "nginx_landing"
+        - path: "/var/log/nginx/{{ sandstorm_hostname }}/*.log"
+          document_type: "reverse_proxy"
+      elasticsearch_addresses:
+        - 'http://172.19.22.1:9200'
+      filebeat_ssl_enabled: true
+      filebeat_certificate_path: test/filebeat.crt
+      filebeat_certificate_key_path: test/filebeat.key
+      filebeat_certificate_authorities:
+        - /etc/filebeat/ssl/filebeat.crt

--- a/test/gen-filebeat-cert.sh
+++ b/test/gen-filebeat-cert.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+cd $(dirname $0)
+
+openssl req -x509 -batch -nodes -days 3650 -newkey rsa:2048 -keyout filebeat.key -out filebeat.crt

--- a/test/gen-logstash-cert.sh
+++ b/test/gen-logstash-cert.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+cd $(dirname $0)
+
+openssl req -x509 -batch -nodes -days 3650 -newkey rsa:2048 -keyout logstash-forwarder.key -out logstash-forwarder.crt

--- a/test/gen-logstash-cert.sh
+++ b/test/gen-logstash-cert.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-cd $(dirname $0)
-
-openssl req -x509 -batch -nodes -days 3650 -newkey rsa:2048 -keyout logstash-forwarder.key -out logstash-forwarder.crt


### PR DESCRIPTION
Forwarding to an external ELK stack is working. I need to refactor
the filebeat client into a role on it's own eventually, but I'm
not sure the best way to proceed with testing.
In my setup, I used a [docker based elk
stack](https://github.com/blacktop/docker-elk) and logs were coming
through. There is still a fair bit of work that needs to be done
to make these logs useful and searchable, as at the moment ES
does not know how to parse the fields in our logs.
Sending logs over SSL will require some orchestration of certs,
but in manually testing it appeared to work.
