### PR TITLE
Filter nginx access logs to remove IP addresses

### DIFF
--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -50,6 +50,12 @@
     dest: "/var/www/502.html"
     content: "502: oops, something went wrong"
 
+- name: filter nginx logs to remove IPs
+  template:
+    src: nginx.conf.j2
+    dest: /etc/nginx/nginx.conf
+  notify: restart nginx
+
 - name: configure nginx reverse proxy
   template:
     src: reverse_proxy.conf.j2

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -1,0 +1,39 @@
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    map $remote_addr $anon_remote_addr {
+        "~^(?<ip_a>\d+\.\d+)\.\d+\.\d+" "$ip_a";
+      }
+    log_format combined_anon '$anon_remote_addr.0.0 - $remote_user [$time_local] '
+                               '"$request" $status $body_bytes_sent '
+                               '"$http_referer" "$http_user_agent"';
+    access_log /var/log/nginx/access.log combined_anon;
+
+    include /etc/nginx/conf.d/*.conf;
+
+}
+

--- a/templates/reverse_proxy.conf.j2
+++ b/templates/reverse_proxy.conf.j2
@@ -19,7 +19,7 @@ server {
   server_name {{ sandstorm_hostname }} {{ sandstorm_wildcard_host }};
 
   error_log /var/log/nginx/{{ sandstorm_hostname }}/error.log;
-  access_log /var/log/nginx/{{ sandstorm_hostname }}/access.log;
+  access_log /var/log/nginx/{{ sandstorm_hostname }}/access.log combined_anon;
 
   # https://mozilla.github.io/server-side-tls/ssl-config-generator/?server=nginx-1.6.2&openssl=1.0.1k&hsts=yes&profile=modern
   # as of Oct 18 2015


### PR DESCRIPTION
This map removes the last two octets on IP addresses in access
logs.
