### PR TITLE
Copy-paste requirements.yml items under meta dependencies

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,7 +12,16 @@ galaxy_info:
   - web
 
 dependencies:
-  - jnv.unattended-upgrades
-  - geerlingguy.firewall
-  - hardening.os-hardening
-  - jacksingleton.ramfs
+  - src: jnv.unattended-upgrades
+    version: v1.1.1
+
+  - src: geerlingguy.firewall
+    version: 1.0.9
+
+  - src: https://github.com/hardening-io/ansible-os-hardening
+    name: hardening.os-hardening
+
+  - src: debops.cryptsetup
+    version: v0.2.1
+
+  - src: jacksingleton.ramfs


### PR DESCRIPTION
When installing through ansible-galaxy currently, `hardening.os-hardening`
is not a valid ansible-galaxy name and therefore it fails to download as
it is currently listed without "- src:" in `meta/main.yml`

`meta/main.yml` supports the same YAML format that you're using in
requirements.yml, where `hardening.os-hardware` would then be downloaded
from SCM as intended.

Additionally, no versions are specified currently in the dependencies
list, so copying that over works too.